### PR TITLE
feat: add admin login and company management

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,16 @@ npm run dev
 | Variable       | Descripción                          |
 | -------------- | ------------------------------------ |
 | `DATABASE_URL` | URL de conexión a la base PostgreSQL |
+| `NEXT_PUBLIC_ALLOWED_ORIGINS` | Dominios permitidos para recibir `postMessage` |
+| `JWT_SECRET` | Clave usada para firmar y verificar tokens |
+| `ADMIN_EMAIL` | Correo del usuario administrador |
+| `ADMIN_PASSWORD` | Contraseña del usuario administrador |
 
 ---
+
+### Panel de administración
+
+Configura `ADMIN_EMAIL` y `ADMIN_PASSWORD` para habilitar el panel en `/admin`. Tras iniciar sesión se puede registrar nuevas compañías desde `/admin/companies`.
 
 ## 🐳 docker-compose.yml (opcional para desarrollo)
 

--- a/env.template
+++ b/env.template
@@ -7,3 +7,7 @@ DATABASE_URL="postgresql://userone:passone@127.0.0.1:5432/db_one_cotizador"
 NEXT_PUBLIC_ALLOWED_ORIGINS=
 
 JWT_SECRET=
+
+# Credenciales para el panel de administración
+ADMIN_EMAIL=
+ADMIN_PASSWORD=

--- a/src/app/(sections)/admin/actions.ts
+++ b/src/app/(sections)/admin/actions.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { cookies } from "next/headers";
+import jwt from "jsonwebtoken";
+import { Country } from "@prisma/client";
+
+const JWT_SECRET = process.env.JWT_SECRET || "secret";
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+
+export async function adminLogin(email: string, password: string) {
+  if (email !== ADMIN_EMAIL || password !== ADMIN_PASSWORD) {
+    return { success: false, message: "Credenciales inválidas" };
+  }
+
+  const token = jwt.sign({ role: "ADMIN", email }, JWT_SECRET, {
+    expiresIn: "2h",
+  });
+
+  const cookieStore = await cookies();
+  cookieStore.set({
+    name: "admin_token",
+    value: token,
+    httpOnly: true,
+    path: "/",
+    maxAge: 3600 * 2,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+
+  return { success: true };
+}
+
+export async function verifyAdmin() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  if (!token) {
+    throw new Error("No autorizado");
+  }
+  const payload = jwt.verify(token, JWT_SECRET) as { role: string };
+  if (payload.role !== "ADMIN") {
+    throw new Error("No autorizado");
+  }
+  return true;
+}
+
+interface CompanyData {
+  businessIdentifier: string;
+  companyName: string;
+  email: string;
+  country: Country;
+  currencyId: number;
+}
+
+export async function createCompany(data: CompanyData) {
+  await verifyAdmin();
+  try {
+    await prisma.company.create({
+      data: {
+        businessIdentifier: data.businessIdentifier,
+        companyName: data.companyName,
+        email: data.email,
+        country: data.country,
+        currency: { connect: { id: data.currencyId } },
+      },
+    });
+    return { success: true };
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Error desconocido";
+    return { success: false, message };
+  }
+}
+
+export async function getCurrencies() {
+  await verifyAdmin();
+  return prisma.currency.findMany({ select: { id: true, value: true } });
+}

--- a/src/app/(sections)/admin/companies/CompanyForm.tsx
+++ b/src/app/(sections)/admin/companies/CompanyForm.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Button, Form, Input, Select, message } from "antd";
+import { createCompany } from "../actions";
+import { Country } from "@prisma/client";
+
+type Props = {
+  currencies: { id: number; value: string }[];
+};
+
+interface FormValues {
+  businessIdentifier: string;
+  companyName: string;
+  email: string;
+  country: Country;
+  currencyId: number;
+}
+
+export default function CompanyForm({ currencies }: Props) {
+  const onFinish = async (values: FormValues) => {
+    const res = await createCompany({
+      businessIdentifier: values.businessIdentifier,
+      companyName: values.companyName,
+      email: values.email,
+      country: values.country,
+      currencyId: values.currencyId,
+    });
+    if (res.success) {
+      message.success("Compañía creada");
+    } else {
+      message.error(res.message || "Error al crear compañía");
+    }
+  };
+
+  return (
+    <Form onFinish={onFinish} layout="vertical" style={{ maxWidth: 400 }}>
+      <Form.Item
+        label="Identificador"
+        name="businessIdentifier"
+        rules={[{ required: true, message: "Identificador requerido" }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Nombre"
+        name="companyName"
+        rules={[{ required: true, message: "Nombre requerido" }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Email"
+        name="email"
+        rules={[{ required: true, message: "Email requerido" }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item label="País" name="country" rules={[{ required: true }]}> 
+        <Select options={Object.values(Country).map((c) => ({ label: c, value: c }))} />
+      </Form.Item>
+      <Form.Item
+        label="Moneda"
+        name="currencyId"
+        rules={[{ required: true, message: "Moneda requerida" }]}
+      >
+        <Select options={currencies.map((c) => ({ label: c.value, value: c.id }))} />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit" block>
+          Guardar
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/app/(sections)/admin/companies/page.tsx
+++ b/src/app/(sections)/admin/companies/page.tsx
@@ -1,0 +1,13 @@
+import { getCurrencies, verifyAdmin } from "../actions";
+import CompanyForm from "./CompanyForm";
+
+export default async function Page() {
+  await verifyAdmin();
+  const currencies = await getCurrencies();
+  return (
+    <div className="flex flex-col items-center mt-8">
+      <h2 className="text-2xl font-bold mb-4">Crear empresa</h2>
+      <CompanyForm currencies={currencies} />
+    </div>
+  );
+}

--- a/src/app/(sections)/admin/page.tsx
+++ b/src/app/(sections)/admin/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Button, Form, Input, message } from "antd";
+import { useRouter } from "next/navigation";
+import { adminLogin } from "./actions";
+
+interface LoginValues {
+  email: string;
+  password: string;
+}
+
+export default function AdminPage() {
+  const router = useRouter();
+
+  const onFinish = async (values: LoginValues) => {
+    const res = await adminLogin(values.email, values.password);
+    if (res.success) {
+      message.success("Bienvenido");
+      router.replace("/admin/companies");
+    } else {
+      message.error(res.message);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center mt-8">
+      <h2 className="text-2xl font-bold">Acceso Administrador</h2>
+      <Form onFinish={onFinish} className="mt-4" style={{ maxWidth: 300, width: "100%" }}>
+        <Form.Item name="email" rules={[{ required: true, message: "Email requerido" }]}> 
+          <Input placeholder="Email" />
+        </Form.Item>
+        <Form.Item name="password" rules={[{ required: true, message: "Password requerida" }]}>
+          <Input.Password placeholder="Password" />
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" htmlType="submit" block>
+            Ingresar
+          </Button>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+}

--- a/src/app/(sections)/auth/_fetures/action.ts
+++ b/src/app/(sections)/auth/_fetures/action.ts
@@ -97,7 +97,7 @@ export async function verifyToken() {
     }
 
     try {
-        const decoded = jwt.verify(token, JWT_SECRET) as unknown as ResVerify;
+        const decoded = jwt.verify(token!, JWT_SECRET) as unknown as ResVerify;
         return decoded;
     } catch {
         throw new Error("No autorizado - token inválido");


### PR DESCRIPTION
## Summary
- document admin credentials in env template and README
- add server actions for admin login, session verification and company registration
- implement admin login UI and company creation form
- ensure auth token exists before verification

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c062844083258f070acd67035ce9